### PR TITLE
feat: refresh marketing site with dark theme and motion

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,23 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { useEffect } from "react";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { inViewReveal } from "./lib/motion";
 
 const queryClient = new QueryClient();
+
+const RouteReveal = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    inViewReveal();
+  }, [location]);
+
+  return null;
+};
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -14,6 +26,7 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
+        <RouteReveal />
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/frontend/src/components/FAQ.tsx
+++ b/frontend/src/components/FAQ.tsx
@@ -43,29 +43,28 @@ const FAQ = () => {
   ];
 
   return (
-    <section className="section-padding bg-muted/20">
-      <div className="container max-w-4xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
+    <section className="section-padding">
+      <div className="container max-w-4xl">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">
             Frequently Asked Questions
           </h2>
-          <p className="text-xl text-muted-foreground text-balance">
-            Everything you need to know about NextEdge
-          </p>
+          <p className="reveal text-muted">Everything you need to know about NextEdge</p>
         </div>
 
-        <div className="bg-background rounded-2xl shadow-enterprise p-8">
+        <div className="mt-14 rounded-card border border-border/60 bg-surface/80 p-8">
           <Accordion type="single" collapsible className="space-y-4">
             {faqs.map((faq, index) => (
-              <AccordionItem 
-                key={index} 
+              <AccordionItem
+                key={index}
                 value={`item-${index}`}
-                className="border border-border rounded-lg px-6"
+                className="reveal overflow-hidden rounded-card border border-border/60 bg-bg/60"
+                style={{ transitionDelay: `${index * 60}ms` }}
               >
-                <AccordionTrigger className="text-left text-lg font-semibold text-foreground hover:text-primary transition-colors">
+                <AccordionTrigger className="px-6 py-4 text-left text-lg font-semibold text-text transition duration-hover ease-fluid hover:text-primary">
                   {faq.question}
                 </AccordionTrigger>
-                <AccordionContent className="text-muted-foreground leading-relaxed pt-2 text-base">
+                <AccordionContent className="px-6 pb-4 text-sm leading-relaxed text-muted">
                   {faq.answer}
                 </AccordionContent>
               </AccordionItem>

--- a/frontend/src/components/FinalCTA.tsx
+++ b/frontend/src/components/FinalCTA.tsx
@@ -4,44 +4,37 @@ import { ArrowRight, CheckCircle } from "lucide-react";
 
 const FinalCTA = () => {
   return (
-    <section className="section-padding bg-gradient-hero">
-      <div className="container max-w-7xl mx-auto text-center">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-3xl md:text-5xl lg:text-6xl font-bold text-foreground mb-6">
+    <section className="section-padding relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,rgba(91,140,255,0.2),transparent_55%)]" />
+      <div className="container text-center">
+        <div className="mx-auto max-w-3xl space-y-8">
+          <h2 className="reveal text-[clamp(36px,5vw,64px)] font-semibold tracking-tight text-text">
             Ready to automate your CRM?
           </h2>
-          
-          <p className="text-xl md:text-2xl text-muted-foreground mb-8 text-balance">
-            Save hours every week with perfect CRM hygiene
-          </p>
-          
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
-            <Button variant="cta" size="xl" className="group">
+
+          <p className="reveal text-lg text-muted md:text-xl">Save hours every week with perfect CRM hygiene</p>
+
+          <div className="reveal flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Button variant="primary" size="xl" className="btn-primary px-10">
               Book a Demo
-              <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
+              <ArrowRight className="ml-2 h-5 w-5" />
             </Button>
           </div>
-          
-          <div className="flex flex-col sm:flex-row gap-6 justify-center items-center text-sm text-muted-foreground">
+
+          <div className="reveal flex flex-col items-center justify-center gap-6 text-sm text-muted sm:flex-row">
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-4 w-4 text-success" />
+              <CheckCircle className="h-4 w-4 text-accent" />
               <span>Free setup & training</span>
             </div>
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-4 w-4 text-success" />
+              <CheckCircle className="h-4 w-4 text-accent" />
               <span>14-day trial</span>
             </div>
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-4 w-4 text-success" />
+              <CheckCircle className="h-4 w-4 text-accent" />
               <span>No long-term commitment</span>
             </div>
           </div>
-        </div>
-        
-        {/* Background Decoration */}
-        <div className="absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute top-0 left-1/4 w-64 h-64 bg-primary/10 rounded-full blur-3xl animate-pulse-primary"></div>
-          <div className="absolute bottom-0 right-1/4 w-80 h-80 bg-primary/10 rounded-full blur-3xl animate-pulse-primary delay-1000"></div>
         </div>
       </div>
     </section>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -5,30 +5,34 @@ import { Linkedin, Twitter, Instagram, Youtube, Facebook, Github } from "lucide-
 const Footer = () => {
   const footerLinks = {
     product: ["Product", "Integrations", "Pricing", "Security"],
-    legal: ["Contact", "Privacy Policy", "Terms"]
+    legal: ["Contact", "Privacy Policy", "Terms"],
   };
+  const socials = [
+    { icon: Linkedin, label: "LinkedIn" },
+    { icon: Twitter, label: "Twitter" },
+    { icon: Instagram, label: "Instagram" },
+    { icon: Youtube, label: "YouTube" },
+    { icon: Facebook, label: "Facebook" },
+    { icon: Github, label: "GitHub" },
+  ];
 
   return (
-    <footer className="bg-muted text-muted-foreground">
-      <div className="container max-w-7xl mx-auto px-4 py-12">
-        <div className="grid md:grid-cols-4 gap-8">
+    <footer className="border-t border-border/60 bg-surface/60 text-muted">
+      <div className="container py-12">
+        <div className="grid gap-10 md:grid-cols-4">
           {/* Brand */}
-          <div className="md:col-span-2">
-            <div className="text-2xl font-bold text-foreground mb-4">
-              NextEdge
-            </div>
-            <p className="text-base text-muted-foreground">
-              CRM that works, without the work
-            </p>
+          <div className="reveal md:col-span-2 space-y-3">
+            <div className="text-2xl font-semibold text-text">NextEdge</div>
+            <p className="text-sm text-muted">CRM that works, without the work</p>
           </div>
 
           {/* Links */}
-          <div>
-            <h4 className="font-semibold text-foreground mb-3">Product</h4>
-            <ul className="space-y-2">
+          <div className="reveal space-y-3" style={{ transitionDelay: "80ms" }}>
+            <h4 className="text-sm font-semibold uppercase tracking-[0.28em] text-muted">Product</h4>
+            <ul className="space-y-2 text-sm">
               {footerLinks.product.map((link) => (
                 <li key={link}>
-                  <a href="#" className="text-base hover:text-primary transition-colors">
+                  <a href="#" className="transition duration-hover ease-fluid hover:text-primary">
                     {link}
                   </a>
                 </li>
@@ -36,12 +40,12 @@ const Footer = () => {
             </ul>
           </div>
 
-          <div>
-            <h4 className="font-semibold text-foreground mb-3">Legal</h4>
-            <ul className="space-y-2">
+          <div className="reveal space-y-3" style={{ transitionDelay: "160ms" }}>
+            <h4 className="text-sm font-semibold uppercase tracking-[0.28em] text-muted">Legal</h4>
+            <ul className="space-y-2 text-sm">
               {footerLinks.legal.map((link) => (
                 <li key={link}>
-                  <a href="#" className="text-base hover:text-primary transition-colors">
+                  <a href="#" className="transition duration-hover ease-fluid hover:text-primary">
                     {link}
                   </a>
                 </li>
@@ -51,37 +55,22 @@ const Footer = () => {
         </div>
 
         <Separator className="my-8" />
-        
-        <div className="flex flex-col md:flex-row justify-between items-center">
-          <div className="text-base">
-            © 2025 NextEdge. All rights reserved.
-          </div>
-          
-          <div className="flex items-center gap-4 mt-4 md:mt-0">
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">LinkedIn</span>
-              <Linkedin className="w-5 h-5" />
-            </a>
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">Twitter</span>
-              <Twitter className="w-5 h-5" />
-            </a>
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">Instagram</span>
-              <Instagram className="w-5 h-5" />
-            </a>
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">YouTube</span>
-              <Youtube className="w-5 h-5" />
-            </a>
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">Facebook</span>
-              <Facebook className="w-5 h-5" />
-            </a>
-            <a href="#" className="hover:text-primary transition-colors hover:scale-110 transform duration-200">
-              <span className="sr-only">GitHub</span>
-              <Github className="w-5 h-5" />
-            </a>
+
+        <div className="reveal flex flex-col items-center justify-between gap-6 text-sm text-muted md:flex-row" style={{ transitionDelay: "240ms" }}>
+          <div>© 2025 NextEdge. All rights reserved.</div>
+
+          <div className="flex items-center gap-4">
+            {socials.map(({ icon: Icon, label }, index) => (
+              <a
+                key={label}
+                href="#"
+                className="reveal transition duration-hover ease-fluid hover:text-primary"
+                style={{ transitionDelay: `${300 + index * 40}ms` }}
+              >
+                <span className="sr-only">{label}</span>
+                <Icon className="h-5 w-5" />
+              </a>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,38 +10,38 @@ const Header = () => {
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-16 max-w-7xl items-center justify-between">
+    <header className="sticky top-0 z-50 w-full border-b border-border/60 bg-bg/80 backdrop-blur supports-[backdrop-filter]:bg-bg/75">
+      <div className="container flex h-16 items-center justify-between">
         {/* Logo */}
         <div className="flex items-center">
-          <img 
-            src="/lovable-uploads/adc57d85-0a2e-43b2-91d1-45cf3e175ec3.png" 
-            alt="NEXTEDGE" 
-            className="h-8 w-auto"
+          <img
+            src="/lovable-uploads/adc57d85-0a2e-43b2-91d1-45cf3e175ec3.png"
+            alt="NEXTEDGE"
+            className="h-8 w-auto drop-shadow-[0_6px_18px_rgba(91,140,255,0.25)]"
           />
         </div>
 
         {/* Desktop Navigation */}
-        <nav className="hidden md:flex items-center space-x-8">
-          <a href="#product" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
+        <nav className="hidden items-center space-x-8 md:flex">
+          <a href="#product" className="text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
             Product
           </a>
-          <a href="#integrations" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
+          <a href="#integrations" className="text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
             Integrations
           </a>
-          <a href="#pricing" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
+          <a href="#pricing" className="text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
             Pricing
           </a>
-          <a href="#security" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
+          <a href="#security" className="text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
             Security
           </a>
-          <a href="#contact" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
+          <a href="#contact" className="text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
             Contact
           </a>
         </nav>
 
         {/* Desktop CTA Buttons */}
-        <div className="hidden md:flex items-center space-x-4">
+        <div className="hidden items-center space-x-3 md:flex">
           <SignedOut>
             <SignInButton mode="modal">
               <Button variant="nav" size="sm">
@@ -49,16 +49,16 @@ const Header = () => {
               </Button>
             </SignInButton>
             <SignUpButton mode="modal">
-              <Button variant="hero" size="sm">
+              <Button variant="outline" size="sm" className="rounded-pill px-6">
                 Sign Up
               </Button>
             </SignUpButton>
-            <Button variant="hero" size="sm">
+            <Button variant="primary" size="sm" className="btn-primary px-6">
               Book a Demo
             </Button>
           </SignedOut>
           <SignedIn>
-            <Button variant="hero" size="sm">
+            <Button variant="primary" size="sm" className="btn-primary px-6">
               Book a Demo
             </Button>
             <UserButton afterSignOutUrl="/" />
@@ -68,7 +68,7 @@ const Header = () => {
         {/* Mobile Menu Button */}
         <button
           onClick={toggleMenu}
-          className="md:hidden p-2 text-foreground hover:text-primary"
+          className="rounded-button p-2 text-muted transition duration-hover ease-fluid hover:text-text md:hidden"
           aria-label="Toggle menu"
         >
           {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,24 +77,24 @@ const Header = () => {
 
       {/* Mobile Navigation */}
       {isMenuOpen && (
-        <div className="md:hidden border-t bg-background/95 backdrop-blur">
-          <nav className="container py-4 space-y-4">
-            <a href="#product" className="block text-sm font-medium text-foreground hover:text-primary transition-colors">
+        <div className="border-t border-border/60 bg-bg/95 backdrop-blur md:hidden">
+          <nav className="container space-y-4 py-4">
+            <a href="#product" className="block text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
               Product
             </a>
-            <a href="#integrations" className="block text-sm font-medium text-foreground hover:text-primary transition-colors">
+            <a href="#integrations" className="block text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
               Integrations
             </a>
-            <a href="#pricing" className="block text-sm font-medium text-foreground hover:text-primary transition-colors">
+            <a href="#pricing" className="block text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
               Pricing
             </a>
-            <a href="#security" className="block text-sm font-medium text-foreground hover:text-primary transition-colors">
+            <a href="#security" className="block text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
               Security
             </a>
-            <a href="#contact" className="block text-sm font-medium text-foreground hover:text-primary transition-colors">
+            <a href="#contact" className="block text-sm font-medium text-muted transition duration-hover ease-fluid hover:text-text">
               Contact
             </a>
-            <div className="flex flex-col space-y-3 pt-4 border-t">
+            <div className="flex flex-col space-y-3 border-t border-border/60 pt-4">
               <SignedOut>
                 <SignInButton mode="modal">
                   <Button variant="nav" size="sm">
@@ -102,16 +102,16 @@ const Header = () => {
                   </Button>
                 </SignInButton>
                 <SignUpButton mode="modal">
-                  <Button variant="hero" size="sm">
+                  <Button variant="outline" size="sm" className="rounded-pill">
                     Sign Up
                   </Button>
                 </SignUpButton>
-                <Button variant="hero" size="sm">
+                <Button variant="primary" size="sm" className="btn-primary">
                   Book a Demo
                 </Button>
               </SignedOut>
               <SignedIn>
-                <Button variant="hero" size="sm">
+                <Button variant="primary" size="sm" className="btn-primary">
                   Book a Demo
                 </Button>
                 <div className="flex items-center">

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import { useEffect, useRef } from "react";
 import { Button } from "./ui/button-enhanced";
 import { ArrowRight, Play } from "lucide-react";
+import { floatY } from "@/lib/motion";
 
 const Hero = () => {
   const stats = [
@@ -8,55 +9,62 @@ const Hero = () => {
     { number: "2.5M+", label: "Records Enriched" },
     { number: "500K+", label: "Dupes Fixed" }
   ];
+  const statsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = statsRef.current;
+    if (!element) return;
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (reduceMotion.matches) return;
+
+    const stop = floatY(element, 8, 7000);
+
+    return () => {
+      stop();
+      element.style.transform = "";
+    };
+  }, []);
 
   return (
-    <section className="relative overflow-hidden bg-gradient-hero section-padding">
-      <div className="container relative z-10 max-w-7xl mx-auto text-center">
-        <div className="animate-fade-up">
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight text-balance mb-6">
-            <span className="text-foreground">AI that updates your CRM for you,</span>
+    <section className="section-padding relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(91,140,255,0.18),transparent_55%)]" />
+      <div className="container relative z-10 flex flex-col items-center text-center gap-12">
+        <div className="max-w-heading text-balance space-y-6">
+          <h1 className="reveal text-[clamp(40px,6vw,72px)] font-bold tracking-tight">
+            <span className="text-text">AI that updates your CRM for you,</span>
             <br />
             <span className="text-primary">perfectly.</span>
           </h1>
-          
-          <p className="text-xl md:text-2xl text-muted-foreground max-w-3xl mx-auto mb-12 text-balance">
-            Auto-capture every email, meeting, and note — then sync clean, enriched data into your CRM.
-          </p>
-          
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
-            <Button variant="hero" size="xl" className="group">
-              Book a Demo
-              <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
-            </Button>
-            <Button variant="hero-outline" size="xl" className="group">
-              <Play className="mr-2 h-5 w-5 transition-transform group-hover:scale-110" />
-              Learn More
-            </Button>
-          </div>
-
-          {/* Stats Cards */}
-          <div className="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
-            {stats.map((stat, index) => (
-              <div 
-                key={stat.label}
-                className="bg-background/80 backdrop-blur-sm border border-border rounded-xl p-6 text-center hover-lift"
-                style={{ animationDelay: `${index * 200}ms` }}
-              >
-                <div className="text-3xl font-bold text-primary mb-2">
-                  {stat.number}
-                </div>
-                <div className="text-base font-medium text-muted-foreground">
-                  {stat.label}
-                </div>
-              </div>
-            ))}
-          </div>
         </div>
-        
-        {/* Hero Background Decoration */}
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute top-0 left-0 w-72 h-72 bg-primary/5 rounded-full blur-3xl animate-pulse-primary"></div>
-          <div className="absolute bottom-0 right-0 w-96 h-96 bg-primary/5 rounded-full blur-3xl animate-pulse-primary delay-1000"></div>
+
+        <p className="reveal max-w-body text-lg text-muted md:text-xl">
+          Auto-capture every email, meeting, and note — then sync clean, enriched data into your CRM.
+        </p>
+
+        <div className="reveal flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button variant="primary" size="xl" className="btn-primary px-10">
+            Book a Demo
+            <ArrowRight className="ml-2 h-5 w-5" />
+          </Button>
+          <Button variant="outline" size="xl" className="px-10">
+            <Play className="mr-2 h-5 w-5" />
+            Learn More
+          </Button>
+        </div>
+
+        {/* Stats Cards */}
+        <div ref={statsRef} className="grid w-full max-w-4xl grid-cols-1 gap-4 md:grid-cols-3">
+          {stats.map((stat, index) => (
+            <div
+              key={stat.label}
+              className="reveal surface-card p-6 text-left shadow-[0_18px_40px_rgba(4,6,12,0.45)]"
+              style={{ transitionDelay: `${index * 80}ms` }}
+            >
+              <div className="text-3xl font-semibold text-primary">{stat.number}</div>
+              <div className="mt-2 text-sm uppercase tracking-[0.24em] text-muted">{stat.label}</div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -26,50 +26,32 @@ const HowItWorks = () => {
 
   return (
     <section className="section-padding" id="product">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            How It Works
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">How It Works</h2>
+          <p className="reveal text-muted">
             Three simple steps to transform your CRM data quality forever
           </p>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8 lg:gap-12">
+        <div className="mt-14 grid gap-6 md:grid-cols-3">
           {steps.map((step, index) => {
             const IconComponent = step.icon;
             return (
-              <div
+              <Card
                 key={step.number}
-                className="relative group"
-                style={{ animationDelay: `${index * 200}ms` }}
+                className="reveal h-full"
+                style={{ transitionDelay: `${index * 80}ms` }}
               >
-                <Card className="hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 h-full">
-                  <CardContent className="p-8 text-center">
-                    <div className="flex items-center justify-center w-16 h-16 bg-primary-light rounded-full mb-6 mx-auto group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300">
-                      <IconComponent className="h-8 w-8 text-primary group-hover:text-primary-foreground transition-colors duration-300" />
-                    </div>
-                    
-                    <div className="text-xs font-mono text-primary mb-2 tracking-wider">
-                      STEP {step.number}
-                    </div>
-                    
-                    <h3 className="text-xl font-bold text-foreground mb-4">
-                      {step.title}
-                    </h3>
-                    
-                    <p className="text-muted-foreground leading-relaxed">
-                      {step.description}
-                    </p>
-                  </CardContent>
-                </Card>
-
-                {/* Connection Line */}
-                {index < steps.length - 1 && (
-                  <div className="hidden md:block absolute top-1/2 -right-6 lg:-right-12 w-12 lg:w-24 h-px bg-gradient-to-r from-primary/50 to-transparent"></div>
-                )}
-              </div>
+                <CardContent className="flex h-full flex-col items-center gap-6 p-8 text-center">
+                  <div className="flex h-16 w-16 items-center justify-center rounded-pill bg-primary/15 text-primary">
+                    <IconComponent className="h-8 w-8" />
+                  </div>
+                  <div className="text-xs font-mono tracking-[0.32em] text-muted">STEP {step.number}</div>
+                  <h3 className="text-xl font-semibold text-text">{step.title}</h3>
+                  <p className="text-sm leading-relaxed text-muted">{step.description}</p>
+                </CardContent>
+              </Card>
             );
           })}
         </div>

--- a/frontend/src/components/Integrations.tsx
+++ b/frontend/src/components/Integrations.tsx
@@ -16,52 +16,44 @@ const Integrations = () => {
   ];
 
   return (
-    <section className="section-padding bg-muted/20" id="integrations">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
+    <section className="section-padding" id="integrations">
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">
             Connect NextEdge to the tools you already use
           </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
-            Seamless integrations with your existing workflow
-          </p>
+          <p className="reveal text-muted">Seamless integrations with your existing workflow</p>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-6 mb-12">
+        <div className="mt-14 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-8">
           {integrations.map((integration, index) => {
             const IconComponent = integration.icon;
             return (
               <Card
                 key={integration.name}
-                className="group hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 aspect-square"
-                style={{ animationDelay: `${index * 100}ms` }}
+                className="reveal aspect-square"
+                style={{ transitionDelay: `${index * 60}ms` }}
               >
-                <CardContent className="p-4 flex flex-col items-center justify-center h-full text-center">
-                  <div className="flex items-center justify-center w-12 h-12 bg-primary-light rounded-lg mb-3 group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300">
-                    <IconComponent className="h-6 w-6 text-primary group-hover:text-primary-foreground transition-colors duration-300" />
+                <CardContent className="flex h-full flex-col items-center justify-center gap-3 text-center">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-pill bg-primary/15 text-primary">
+                    <IconComponent className="h-6 w-6" />
                   </div>
-                  
-                  <div className="text-sm font-semibold text-foreground mb-1">
-                    {integration.name}
-                  </div>
-                  
-                  <div className="text-xs text-muted-foreground">
-                    {integration.category}
-                  </div>
+                  <div className="text-sm font-semibold text-text">{integration.name}</div>
+                  <div className="text-xs uppercase tracking-[0.28em] text-muted">{integration.category}</div>
                 </CardContent>
               </Card>
             );
           })}
         </div>
 
-        <div className="text-center">
-          <p className="text-muted-foreground mb-6">
-            Plus 50+ more integrations available
-          </p>
-          <Button variant="hero-outline" size="lg" className="group">
+        <div className="mt-12 space-y-4 text-center">
+          <p className="reveal text-muted">Plus 50+ more integrations available</p>
+          <div className="reveal" style={{ transitionDelay: "120ms" }}>
+            <Button variant="outline" size="lg" className="px-8">
             View All Integrations
-            <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-          </Button>
+            <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/components/ROICalculator.tsx
+++ b/frontend/src/components/ROICalculator.tsx
@@ -21,38 +21,32 @@ const ROICalculator = () => {
 
   return (
     <section className="section-padding" id="roi">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            Prove the ROI in seconds
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
-            Calculate your potential savings with NextEdge automation
-          </p>
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">Prove the ROI in seconds</h2>
+          <p className="reveal text-muted">Calculate your potential savings with NextEdge automation</p>
         </div>
 
-        <div className="max-w-4xl mx-auto">
-          <Card className="shadow-enterprise border-0 overflow-hidden">
-            <CardHeader className="bg-gradient-card border-b">
-              <CardTitle className="flex items-center gap-3 text-2xl">
-                <div className="flex items-center justify-center w-10 h-10 bg-primary rounded-lg">
-                  <Calculator className="h-6 w-6 text-primary-foreground" />
+        <div className="mx-auto mt-14 max-w-4xl">
+          <Card className="reveal overflow-hidden">
+            <CardHeader className="border-b border-border/60 bg-surface/60">
+              <CardTitle className="flex items-center gap-3 text-2xl text-text">
+                <div className="flex h-10 w-10 items-center justify-center rounded-pill bg-primary/20 text-primary">
+                  <Calculator className="h-6 w-6" />
                 </div>
                 ROI Calculator
               </CardTitle>
             </CardHeader>
-            
+
             <CardContent className="p-8">
-              <div className="grid md:grid-cols-2 gap-8">
+              <div className="grid gap-10 md:grid-cols-2">
                 {/* Input Section */}
-                <div className="space-y-6">
-                  <h3 className="text-lg font-semibold text-foreground mb-4">
-                    Your Current Metrics
-                  </h3>
-                  
-                  <div className="space-y-4">
-                    <div>
-                      <Label htmlFor="reps" className="text-sm font-medium text-foreground">
+                <div className="reveal space-y-6 text-left" style={{ transitionDelay: "80ms" }}>
+                  <h3 className="text-lg font-semibold text-text">Your Current Metrics</h3>
+
+                  <div className="space-y-5">
+                    <div className="space-y-2">
+                      <Label htmlFor="reps" className="text-sm font-medium text-text">
                         Number of Sales Reps
                       </Label>
                       <Input
@@ -60,13 +54,12 @@ const ROICalculator = () => {
                         type="number"
                         value={reps}
                         onChange={(e) => setReps(Number(e.target.value))}
-                        className="mt-1"
                         min={1}
                       />
                     </div>
-                    
-                    <div>
-                      <Label htmlFor="hourly" className="text-sm font-medium text-foreground">
+
+                    <div className="space-y-2">
+                      <Label htmlFor="hourly" className="text-sm font-medium text-text">
                         Hourly Cost per Rep ($)
                       </Label>
                       <Input
@@ -74,13 +67,12 @@ const ROICalculator = () => {
                         type="number"
                         value={hourlyCost}
                         onChange={(e) => setHourlyCost(Number(e.target.value))}
-                        className="mt-1"
                         min={1}
                       />
                     </div>
-                    
-                    <div>
-                      <Label htmlFor="hours" className="text-sm font-medium text-foreground">
+
+                    <div className="space-y-2">
+                      <Label htmlFor="hours" className="text-sm font-medium text-text">
                         Hours Saved per Rep per Week
                       </Label>
                       <Input
@@ -88,7 +80,6 @@ const ROICalculator = () => {
                         type="number"
                         value={hoursSaved}
                         onChange={(e) => setHoursSaved(Number(e.target.value))}
-                        className="mt-1"
                         min={1}
                         max={40}
                       />
@@ -97,40 +88,41 @@ const ROICalculator = () => {
                 </div>
 
                 {/* Results Section */}
-                <div className="bg-primary-light/50 rounded-xl p-6 space-y-6">
-                  <div className="flex items-center gap-3 mb-4">
-                    <TrendingUp className="h-6 w-6 text-primary" />
-                    <h3 className="text-lg font-semibold text-foreground">
-                      Your Potential Savings
-                    </h3>
+                <div
+                  className="reveal flex flex-col justify-between gap-6 rounded-card border border-border/60 bg-surface/50 p-6"
+                  style={{ transitionDelay: "160ms" }}
+                >
+                  <div className="flex items-center gap-3">
+                    <TrendingUp className="h-6 w-6 text-accent" />
+                    <h3 className="text-lg font-semibold text-text">Your Potential Savings</h3>
                   </div>
-                  
+
                   <div className="space-y-4">
-                    <div className="p-4 bg-background rounded-lg border">
-                      <div className="text-sm text-muted-foreground mb-1">Monthly Savings</div>
-                      <div className="text-3xl font-bold text-success">
+                    <div className="rounded-card border border-border/60 bg-bg/60 p-5">
+                      <div className="text-sm text-muted">Monthly Savings</div>
+                      <div className="mt-1 text-3xl font-semibold text-accent">
                         ${monthlySavings.toLocaleString()}
                       </div>
                     </div>
-                    
-                    <div className="p-4 bg-background rounded-lg border">
-                      <div className="text-sm text-muted-foreground mb-1">Annual ROI</div>
-                      <div className="text-2xl font-bold text-primary">
+
+                    <div className="rounded-card border border-border/60 bg-bg/60 p-5">
+                      <div className="text-sm text-muted">Annual ROI</div>
+                      <div className="mt-1 text-2xl font-semibold text-primary">
                         ${yearlyROI.toLocaleString()}
                       </div>
                     </div>
-                    
-                    <div className="text-xs text-muted-foreground">
+
+                    <div className="text-xs text-muted">
                       * Based on {reps} reps saving {hoursSaved} hours/week at ${hourlyCost}/hour
                     </div>
                   </div>
                 </div>
               </div>
-              
-              <div className="mt-8 text-center">
-                <Button variant="cta" size="xl" className="group">
+
+              <div className="reveal mt-10 text-center" style={{ transitionDelay: "200ms" }}>
+                <Button variant="primary" size="xl" className="btn-primary px-10">
                   See Your Savings in Action
-                  <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
+                  <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
               </div>
             </CardContent>

--- a/frontend/src/components/Security.tsx
+++ b/frontend/src/components/Security.tsx
@@ -33,46 +33,38 @@ const Security = () => {
 
   return (
     <section className="section-padding" id="security">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">
             Enterprise-grade security and reliability
           </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
-            Your data security and privacy are our top priorities
-          </p>
+          <p className="reveal text-muted">Your data security and privacy are our top priorities</p>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="mt-14 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {securityFeatures.map((feature, index) => {
             const IconComponent = feature.icon;
             return (
               <Card
                 key={feature.title}
-                className="group hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 h-full"
-                style={{ animationDelay: `${index * 150}ms` }}
+                className="reveal h-full"
+                style={{ transitionDelay: `${index * 80}ms` }}
               >
-                <CardContent className="p-6 text-center">
-                  <div className="flex items-center justify-center w-16 h-16 bg-success/10 rounded-full mb-4 mx-auto group-hover:bg-success group-hover:text-success-foreground transition-all duration-300">
-                    <IconComponent className="h-8 w-8 text-success group-hover:text-success-foreground transition-colors duration-300" />
+                <CardContent className="flex h-full flex-col items-center gap-4 p-6 text-center">
+                  <div className="flex h-16 w-16 items-center justify-center rounded-pill bg-accent/20 text-accent">
+                    <IconComponent className="h-8 w-8" />
                   </div>
-                  
-                  <h3 className="text-lg font-bold text-foreground mb-3">
-                    {feature.title}
-                  </h3>
-                  
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {feature.description}
-                  </p>
+                  <h3 className="text-lg font-semibold text-text">{feature.title}</h3>
+                  <p className="text-sm leading-relaxed text-muted">{feature.description}</p>
                 </CardContent>
               </Card>
             );
           })}
         </div>
-        
+
         <div className="mt-12 text-center">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-success/10 text-success rounded-full text-sm font-medium">
-            <Shield className="h-4 w-4" />
+          <div className="reveal inline-flex items-center gap-2 rounded-pill border border-border/60 bg-surface/60 px-5 py-2 text-sm font-medium text-text" style={{ transitionDelay: "160ms" }}>
+            <Shield className="h-4 w-4 text-accent" />
             Enterprise Security & Compliance Ready
           </div>
         </div>

--- a/frontend/src/components/SocialProof.tsx
+++ b/frontend/src/components/SocialProof.tsx
@@ -6,34 +6,22 @@ const SocialProof = () => {
   ];
 
   return (
-    <section className="section-padding bg-muted/20 relative overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-5">
-        <div className="absolute inset-0" style={{
-          backgroundImage: `radial-gradient(circle at 1px 1px, hsl(var(--primary)) 1px, transparent 0)`,
-          backgroundSize: '24px 24px'
-        }} />
-      </div>
-      
-      <div className="container max-w-7xl mx-auto text-center relative">
-        <div className="mb-12">
-          <p className="text-lg text-muted-foreground mb-8 font-medium">
-            Trusted by leading teams and backed by industry leaders
-          </p>
-        </div>
-        
-        <div className="grid grid-cols-2 md:grid-cols-6 gap-6">
+    <section className="section-padding relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_1px_1px,rgba(34,211,238,0.12)_1px,transparent_0)] bg-[length:24px_24px] opacity-40" />
+
+      <div className="container relative text-center">
+        <p className="reveal mx-auto max-w-body text-sm font-semibold uppercase tracking-[0.28em] text-muted">
+          Trusted by leading teams and backed by industry leaders
+        </p>
+
+        <div className="mt-12 grid grid-cols-2 gap-4 md:grid-cols-6">
           {logos.map((logo, index) => (
-            <div 
+            <div
               key={logo}
-              className="group relative"
-              style={{ animationDelay: `${index * 150}ms` }}
+              className="reveal surface-card flex h-20 items-center justify-center rounded-card border border-border/60 text-lg font-semibold text-muted transition duration-hover ease-fluid hover:border-primary/60 hover:text-text"
+              style={{ transitionDelay: `${index * 60}ms` }}
             >
-              <div className="bg-background/80 backdrop-blur-sm border border-border/50 rounded-xl p-6 h-20 flex items-center justify-center shadow-sm hover:shadow-md hover:border-primary/30 transition-all duration-300 hover:scale-105 hover:bg-background animate-fade-up">
-                <div className="text-xl font-bold text-muted-foreground group-hover:text-foreground transition-colors duration-300">
-                  {logo}
-                </div>
-              </div>
+              {logo}
             </div>
           ))}
         </div>

--- a/frontend/src/components/Testimonials.tsx
+++ b/frontend/src/components/Testimonials.tsx
@@ -28,48 +28,38 @@ const Testimonials = () => {
   ];
 
   return (
-    <section className="section-padding bg-muted/20">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            Loved by Sales Leaders
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
-            See what our customers say about NextEdge
-          </p>
+    <section className="section-padding">
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">Loved by Sales Leaders</h2>
+          <p className="reveal text-muted">See what our customers say about NextEdge</p>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="mt-14 grid gap-6 md:grid-cols-3">
           {testimonials.map((testimonial, index) => (
             <Card
               key={testimonial.name}
-              className="group hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 h-full"
-              style={{ animationDelay: `${index * 200}ms` }}
+              className="reveal h-full"
+              style={{ transitionDelay: `${index * 80}ms` }}
             >
-              <CardContent className="p-8 h-full flex flex-col">
-                <div className="flex items-center justify-between mb-6">
+              <CardContent className="flex h-full flex-col gap-6 p-8">
+                <div className="flex items-center justify-between text-primary">
                   <div className="flex items-center gap-1">
                     {[...Array(testimonial.rating)].map((_, i) => (
                       <Star key={i} className="h-4 w-4 fill-primary text-primary" />
                     ))}
                   </div>
-                  <Quote className="h-8 w-8 text-primary/20" />
+                  <Quote className="h-8 w-8 text-primary/30" />
                 </div>
-                
-                <blockquote className="text-foreground leading-relaxed mb-6 flex-grow">
-                  "{testimonial.quote}"
+
+                <blockquote className="text-left text-lg leading-relaxed text-text">
+                  “{testimonial.quote}”
                 </blockquote>
-                
-                <div className="border-t pt-4">
-                  <div className="font-semibold text-foreground">
-                    {testimonial.name}
-                  </div>
-                  <div className="text-sm text-primary font-medium">
-                    {testimonial.role}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {testimonial.company}
-                  </div>
+
+                <div className="mt-auto space-y-1 border-t border-border/60 pt-4 text-left">
+                  <div className="text-base font-semibold text-text">{testimonial.name}</div>
+                  <div className="text-sm font-medium text-primary">{testimonial.role}</div>
+                  <div className="text-sm text-muted">{testimonial.company}</div>
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/components/UseCases.tsx
+++ b/frontend/src/components/UseCases.tsx
@@ -36,53 +36,41 @@ const UseCases = () => {
 
   return (
     <section className="section-padding">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            Who It's For
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
-            NextEdge adapts to your team's unique needs and workflow
-          </p>
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">Who It's For</h2>
+          <p className="reveal text-muted">NextEdge adapts to your team's unique needs and workflow</p>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-8">
+        <div className="mt-14 grid gap-6 md:grid-cols-2">
           {useCases.map((useCase, index) => {
             const IconComponent = useCase.icon;
             return (
               <Card
                 key={useCase.title}
-                className="group hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 h-full"
-                style={{ animationDelay: `${index * 200}ms` }}
+                className="reveal h-full"
+                style={{ transitionDelay: `${index * 80}ms` }}
               >
-                <CardHeader className="pb-4">
+                <CardHeader className="pb-0">
                   <div className="flex items-center gap-4">
-                    <div className="flex items-center justify-center w-12 h-12 bg-primary-light rounded-xl group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300">
-                      <IconComponent className="h-6 w-6 text-primary group-hover:text-primary-foreground transition-colors duration-300" />
+                    <div className="flex h-12 w-12 items-center justify-center rounded-pill bg-primary/15 text-primary">
+                      <IconComponent className="h-6 w-6" />
                     </div>
                     <div>
-                      <CardTitle className="text-xl font-bold text-foreground">
-                        {useCase.title}
-                      </CardTitle>
-                      <p className="text-sm font-medium text-primary">
-                        {useCase.subtitle}
-                      </p>
+                      <CardTitle className="text-xl font-semibold text-text">{useCase.title}</CardTitle>
+                      <p className="text-sm font-medium text-primary">{useCase.subtitle}</p>
                     </div>
                   </div>
                 </CardHeader>
-                
-                <CardContent className="pt-0">
-                  <p className="text-muted-foreground mb-6 leading-relaxed">
-                    {useCase.description}
-                  </p>
-                  
-                  <div className="space-y-2">
+
+                <CardContent className="mt-6 space-y-6">
+                  <p className="text-sm leading-relaxed text-muted">{useCase.description}</p>
+
+                  <div className="space-y-2 text-left">
                     {useCase.benefits.map((benefit, benefitIndex) => (
-                      <div key={benefitIndex} className="flex items-center gap-3">
-                        <div className="w-2 h-2 bg-primary rounded-full flex-shrink-0"></div>
-                        <span className="text-sm text-foreground font-medium">
-                          {benefit}
-                        </span>
+                      <div key={benefitIndex} className="flex items-center gap-3 text-sm text-text">
+                        <span className="flex h-2 w-2 items-center justify-center rounded-full bg-accent" />
+                        <span>{benefit}</span>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/components/ValuePillars.tsx
+++ b/frontend/src/components/ValuePillars.tsx
@@ -31,42 +31,33 @@ const ValuePillars = () => {
   ];
 
   return (
-    <section className="section-padding bg-muted/20">
-      <div className="container max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-5xl font-bold text-foreground mb-4">
-            Why NextEdge
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto text-balance">
+    <section className="section-padding">
+      <div className="container">
+        <div className="mx-auto max-w-body text-center space-y-4">
+          <h2 className="reveal text-4xl font-semibold tracking-tight md:text-5xl">Why NextEdge</h2>
+          <p className="reveal text-muted">
             Four pillars of perfect CRM hygiene, powered by enterprise AI
           </p>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="mt-14 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           {pillars.map((pillar, index) => {
             const IconComponent = pillar.icon;
             return (
               <Card
                 key={pillar.title}
-                className="group hover-lift border-0 shadow-card hover:shadow-enterprise transition-all duration-300 h-full"
-                style={{ animationDelay: `${index * 150}ms` }}
+                className="reveal h-full"
+                style={{ transitionDelay: `${index * 80}ms` }}
               >
-                <CardContent className="p-6">
-                  <div className="flex items-center justify-center w-14 h-14 bg-primary-light rounded-xl mb-4 group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300">
-                    <IconComponent className="h-7 w-7 text-primary group-hover:text-primary-foreground transition-colors duration-300" />
+                <CardContent className="flex h-full flex-col gap-4 p-6">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-pill bg-primary/15 text-primary">
+                    <IconComponent className="h-6 w-6" />
                   </div>
-                  
-                  <h3 className="text-lg font-bold text-foreground mb-2">
-                    {pillar.title}
-                  </h3>
-                  
-                  <p className="text-sm font-medium text-primary mb-3">
-                    {pillar.description}
-                  </p>
-                  
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {pillar.details}
-                  </p>
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-semibold text-text">{pillar.title}</h3>
+                    <p className="text-sm font-medium text-primary">{pillar.description}</p>
+                    <p className="text-sm leading-relaxed text-muted">{pillar.details}</p>
+                  </div>
                 </CardContent>
               </Card>
             );

--- a/frontend/src/components/ui/button-enhanced.tsx
+++ b/frontend/src/components/ui/button-enhanced.tsx
@@ -1,38 +1,36 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-base font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-button text-base font-medium transition-transform duration-hover ease-fluid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow hover:bg-primary-hover hover:shadow-lg transform hover:-translate-y-0.5",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        primary:
+          "btn-primary shadow-[0_18px_40px_rgba(34,211,238,0.18)] hover:-translate-y-0.5 hover:shadow-[0_24px_48px_rgba(91,140,255,0.35)]",
+        secondary: "bg-surface/80 text-text border border-border hover:bg-surface",
+        outline: "border border-border text-text hover:border-primary hover:text-primary",
+        ghost: "text-muted hover:text-text hover:bg-surface/60",
+        subtle: "bg-surface/60 text-muted hover:text-text hover:bg-surface",
         link: "text-primary underline-offset-4 hover:underline",
-        // Enterprise variants for NextEdge
-        hero: "bg-gradient-primary text-primary-foreground shadow-enterprise hover:shadow-enterprise-xl transform hover:-translate-y-1 hover:scale-[1.02] font-semibold",
-        "hero-outline": "border-2 border-primary bg-transparent text-primary shadow-card hover:bg-primary hover:text-primary-foreground transform hover:-translate-y-0.5",
-        cta: "bg-primary text-primary-foreground shadow-lg hover:shadow-enterprise-xl hover:bg-primary-hover transform hover:-translate-y-1 hover:scale-105 font-semibold text-base px-8 py-3",
-        nav: "bg-transparent text-foreground hover:bg-primary-light hover:text-primary font-medium border border-transparent hover:border-primary/20",
+        nav: "text-muted hover:text-text",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-base",
-        lg: "h-12 rounded-lg px-8",
-        xl: "h-14 rounded-xl px-10 text-lg",
+        sm: "h-9 px-4 text-sm",
+        default: "h-11 px-5",
+        lg: "h-12 px-6 text-lg",
+        xl: "h-14 px-7 text-lg",
         icon: "h-10 w-10",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "secondary",
       size: "default",
     },
-  }
+  },
 );
 
 export interface ButtonProps
@@ -44,14 +42,8 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+  },
 );
 Button.displayName = "Button";
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,26 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-button text-sm font-medium transition-transform duration-hover ease-fluid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        primary: "btn-primary",
+        secondary: "bg-surface/80 text-text border border-border hover:bg-surface",
+        outline: "border border-border text-text hover:border-primary hover:text-primary",
+        ghost: "text-muted hover:text-text hover:bg-surface/60",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 px-3",
+        default: "h-10 px-4",
+        lg: "h-11 px-6",
         icon: "h-10 w-10",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "secondary",
       size: "default",
     },
   },

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -3,33 +3,40 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn(
+      "surface-card shadow-[0_24px_60px_rgba(4,6,12,0.35)] transition-colors duration-complex ease-fluid",
+      className,
+    )}
+    {...props}
+  />
 ));
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col space-y-3 p-6", className)} {...props} />
   ),
 );
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+    <h3 ref={ref} className={cn("text-2xl font-semibold text-text", className)} {...props} />
   ),
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
   ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <p ref={ref} className={cn("text-sm text-muted", className)} {...props} />
   ),
 );
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />,
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6", className)} {...props} />,
 );
 CardContent.displayName = "CardContent";
 

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -2,21 +2,22 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>((
+  { className, type, ...props },
+  ref,
+) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-11 w-full rounded-card border border-border bg-surface px-4 text-base text-text placeholder:text-muted transition-colors duration-hover ease-fluid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
 Input.displayName = "Input";
 
 export { Input };

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[120px] w-full rounded-card border border-border bg-surface px-4 py-3 text-base text-text placeholder:text-muted transition-colors duration-hover ease-fluid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60",
         className,
       )}
       ref={ref}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,299 +2,95 @@
 @tailwind components;
 @tailwind utilities;
 
-/* NextEdge Design System - Enterprise B2B CRM Landing Page */
-
 @layer base {
   :root {
-    /* Core Brand Colors - Professional B2B Palette */
-    --background: 0 0% 100%;
-    --foreground: 215 25% 27%;
-    
-    /* Enterprise Blue - Primary Brand Color */
-    --primary: 217 91% 60%;
-    --primary-foreground: 0 0% 100%;
-    --primary-hover: 217 91% 55%;
-    --primary-light: 217 91% 95%;
-    
-    /* Neutral Grays - Clean & Professional */
-    --secondary: 215 20% 65%;
-    --secondary-foreground: 0 0% 100%;
-    --muted: 215 16% 97%;
-    --muted-foreground: 215 13% 65%;
-    
-    /* Surface Colors */
-    --card: 0 0% 100%;
-    --card-foreground: 215 25% 27%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 215 25% 27%;
-    
-    /* Accent Colors */
-    --accent: 215 16% 97%;
-    --accent-foreground: 215 25% 27%;
-    
-    /* Success & Error */
-    --success: 142 76% 36%;
-    --success-foreground: 0 0% 100%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    
-    /* Borders & Inputs */
-    --border: 215 14% 89%;
-    --input: 215 14% 89%;
-    --ring: 217 91% 60%;
-    
-    /* Enterprise Gradients */
-    --gradient-hero: linear-gradient(135deg, hsl(217 91% 60% / 0.05) 0%, hsl(215 16% 97%) 100%);
-    --gradient-card: linear-gradient(145deg, hsl(0 0% 100%) 0%, hsl(215 16% 99%) 100%);
-    --gradient-primary: linear-gradient(135deg, hsl(217 91% 60%) 0%, hsl(217 91% 55%) 100%);
-    
-    /* Shadows - Professional Depth */
-    --shadow-sm: 0 1px 2px 0 hsl(215 25% 27% / 0.05);
-    --shadow-md: 0 4px 6px -1px hsl(215 25% 27% / 0.1), 0 2px 4px -1px hsl(215 25% 27% / 0.06);
-    --shadow-lg: 0 10px 15px -3px hsl(215 25% 27% / 0.1), 0 4px 6px -2px hsl(215 25% 27% / 0.05);
-    --shadow-xl: 0 20px 25px -5px hsl(215 25% 27% / 0.1), 0 10px 10px -5px hsl(215 25% 27% / 0.04);
-    
-    /* Animation Timing */
-    --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    --transition-bounce: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    
-    --radius: 0.75rem;
-
-    --sidebar-background: 0 0% 98%;
-
-    --sidebar-foreground: 240 5.3% 26.1%;
-
-    --sidebar-primary: 240 5.9% 10%;
-
-    --sidebar-primary-foreground: 0 0% 98%;
-
-    --sidebar-accent: 240 4.8% 95.9%;
-
-    --sidebar-accent-foreground: 240 5.9% 10%;
-
-    --sidebar-border: 220 13% 91%;
-
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    color-scheme: dark;
   }
 
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-}
-
-@layer base {
   * {
     @apply border-border;
   }
 
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-bg text-text antialiased;
+    font-family: var(--font-body);
     font-feature-settings: "cv03", "cv04", "cv11";
+    letter-spacing: -0.01em;
+    min-height: 100vh;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-heading);
+    font-weight: 700;
     letter-spacing: -0.01em;
   }
 
-  h1, h2, h3, h4, h5, h6 {
-    font-weight: 700;
-    letter-spacing: -0.02em;
+  p,
+  span,
+  div {
+    font-family: var(--font-body);
+    line-height: 1.6;
   }
 
-  p, span, div {
-    font-weight: 400;
-    line-height: 1.6;
+  a {
+    color: inherit;
   }
 }
 
 @layer components {
-  /* Hero Section Styles */
-  .hero-gradient {
-    background: var(--gradient-hero);
-  }
-  
-  .card-gradient {
-    background: var(--gradient-card);
-  }
-  
-  .primary-gradient {
-    background: var(--gradient-primary);
-  }
-  
-  /* Enterprise Shadows */
-  .shadow-enterprise {
-    box-shadow: var(--shadow-lg);
-  }
-  
-  .shadow-card {
-    box-shadow: var(--shadow-md);
-  }
-  
-  /* Enhanced scroll-triggered animations */
-  .scroll-animate {
-    opacity: 0;
-    transform: translateY(30px);
-    transition: all 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  
-  .scroll-animate.in-view {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  
-  /* Staggered animations */
-  .stagger-1 { transition-delay: 0.1s; }
-  .stagger-2 { transition-delay: 0.2s; }
-  .stagger-3 { transition-delay: 0.3s; }
-  .stagger-4 { transition-delay: 0.4s; }
-  .stagger-5 { transition-delay: 0.5s; }
-  .stagger-6 { transition-delay: 0.6s; }
-  
-  /* Micro-interactions */
-  .micro-bounce {
-    transition: transform 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  }
-  
-  .micro-bounce:hover {
-    transform: translateY(-2px) scale(1.02);
-  }
-  
-  /* Enhanced hover effects */
-  .hover-glow {
-    position: relative;
-    transition: all 0.3s ease;
-  }
-  
-  .hover-glow::before {
-    content: '';
-    position: absolute;
-    inset: -2px;
-    background: linear-gradient(45deg, hsl(var(--primary)) 0%, transparent 70%);
-    border-radius: inherit;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    z-index: -1;
-  }
-  
-  .hover-glow:hover::before {
-    opacity: 0.1;
-  }
-  
-  /* Floating animation for background elements */
-  .float {
-    animation: float 6s ease-in-out infinite;
-  }
-  
-  .float-delayed {
-    animation: float 6s ease-in-out infinite;
-    animation-delay: -3s;
-  }
-  
-  /* Typography Enhancements */
-  .text-balance {
-    text-wrap: balance;
-  }
-  
   .section-padding {
-    @apply py-16 lg:py-24;
+    padding-block: 40px;
   }
-  
-  .container-padding {
-    @apply px-4 sm:px-6 lg:px-8;
+
+  @media (min-width: 768px) {
+    .section-padding {
+      padding-block: 64px;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .section-padding {
+      padding-block: 96px;
+    }
+  }
+
+  .max-w-heading {
+    max-width: min(100%, 12ch);
+  }
+
+  .max-w-body {
+    max-width: min(100%, 46ch);
+  }
+
+  .surface-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+  }
+
+  .section-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    font-size: 0.75rem;
+    color: var(--muted-text);
   }
 }
 
 @layer utilities {
-  /* Custom animations */
-  @keyframes fade-up {
-    from {
-      opacity: 0;
-      transform: translateY(20px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+  .text-balance {
+    text-wrap: balance;
   }
-  
-  @keyframes slide-in-right {
-    from {
-      opacity: 0;
-      transform: translateX(30px);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0);
-    }
+
+  .backdrop-surface {
+    background: radial-gradient(circle at top, rgba(91, 140, 255, 0.08), transparent 55%);
   }
-  
-  @keyframes pulse-primary {
-    0%, 100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.7;
-    }
-  }
-  
-  .animate-pulse-primary {
-    animation: pulse-primary 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  }
-  
-  /* Floating keyframes */
-  @keyframes float {
-    0%, 100% {
-      transform: translateY(0px);
-    }
-    50% {
-      transform: translateY(-10px);
-    }
-  }
-  
-  /* Enhanced fade-up with better easing */
-  @keyframes enhanced-fade-up {
-    from {
-      opacity: 0;
-      transform: translateY(40px) scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-  
-  .animate-enhanced-fade-up {
-    animation: enhanced-fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+
+  .divider {
+    border-color: var(--border);
   }
 }

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -1,0 +1,50 @@
+const getVar = (variable: string, fallback: string) => {
+  if (typeof window === "undefined") return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(variable).trim();
+  return value || fallback;
+};
+
+export const EASE = getVar("--ease", "cubic-bezier(.2,.8,.2,1)");
+export const DUR_ENTER = getVar("--dur-enter", "420ms");
+
+export function inViewReveal(selector = ".reveal", rootMargin = "0px 0px -20% 0px") {
+  if (typeof window === "undefined") return;
+
+  const elements = document.querySelectorAll<HTMLElement>(selector);
+  if (!elements.length || !("IntersectionObserver" in window)) return;
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in-view");
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { rootMargin, threshold: 0 },
+  );
+
+  elements.forEach((element) => observer.observe(element));
+}
+
+export function floatY(element: HTMLElement, amplitude = 6, periodMs = 6000) {
+  if (typeof window === "undefined") return () => undefined;
+  let animationFrame: number;
+  let time = 0;
+
+  const step = () => {
+    const offset = Math.sin((time / periodMs) * Math.PI * 2) * amplitude;
+    element.style.transform = `translateY(${offset}px)`;
+    time += 16.67;
+    animationFrame = window.requestAnimationFrame(step);
+  };
+
+  animationFrame = window.requestAnimationFrame(step);
+
+  return () => {
+    if (animationFrame) {
+      window.cancelAnimationFrame(animationFrame);
+    }
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { ClerkProvider } from "@clerk/clerk-react";
 import App from "./App.tsx";
+import "./styles/tokens.css";
 import "./index.css";
 
 const PUBLISHABLE_KEY = "pk_test_d2lubmluZy1jYW1lbC00LmNsZXJrLmFjY291bnRzLmRldiQ";

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -15,7 +15,7 @@ import Footer from "../components/Footer";
 
 const Index = () => {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-bg text-text">
       <Header />
       <main>
         <Hero />

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -9,11 +9,11 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
+    <div className="flex min-h-screen items-center justify-center bg-bg text-text">
+      <div className="text-center space-y-4">
+        <h1 className="text-[clamp(40px,6vw,72px)] font-bold tracking-tight">404</h1>
+        <p className="text-lg text-muted">Oops! Page not found</p>
+        <a href="/" className="inline-flex items-center justify-center rounded-button border border-border px-6 py-3 text-base font-medium text-text transition duration-hover ease-fluid hover:border-primary hover:text-primary">
           Return to Home
         </a>
       </div>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,53 @@
+:root {
+  --bg: #0F1115;
+  --surface: #151924;
+  --text: #E6E9F2;
+  --muted-text: #A4A9B6;
+  --primary: #5B8CFF;
+  --accent: #22D3EE;
+  --border: #242B3A;
+
+  --font-heading: Inter, system-ui;
+  --font-body: Inter, system-ui;
+
+  --display-size: clamp(40px, 6vw, 72px);
+  --display-weight: 700;
+  --display-track: -1%;
+
+  --h1: 48px/56px;
+  --h2: 36px/44px;
+  --h3: 28px/36px;
+  --body: 16px/26px;
+  --caption: 13px/20px;
+
+  --radius-card: 20px;
+  --radius-button: 20px;
+  --radius-pill: 9999px;
+
+  --ease: cubic-bezier(.2,.8,.2,1);
+  --dur-enter: 420ms;
+  --dur-hover: 180ms;
+  --dur-complex: 600ms;
+  --stagger: 80ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root { --dur-enter: 200ms; }
+  .parallax, .float { animation: none !important; transform: none !important; }
+}
+
+.text-muted { color: var(--muted-text); }
+.bg-surface { background: var(--surface); }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-card); }
+
+.btn-primary {
+  background: var(--primary); color: var(--bg); border-radius: var(--radius-button);
+  transition: transform var(--dur-hover) var(--ease), box-shadow var(--dur-hover) var(--ease);
+}
+.btn-primary:hover { transform: scale(1.03); }
+
+.reveal {
+  opacity: 0; transform: translateY(20px);
+  transition: opacity var(--dur-enter) var(--ease), transform var(--dur-enter) var(--ease);
+}
+.reveal.in-view { opacity: 1; transform: translateY(0); }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,117 +1,82 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
-export default {
+const config = {
   darkMode: ["class"],
   content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
-  prefix: "",
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "24px",
       screens: {
-        "2xl": "1400px",
+        lg: "1200px",
       },
     },
     extend: {
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-          hover: "hsl(var(--primary-hover))",
-          light: "hsl(var(--primary-light))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        success: {
-          DEFAULT: "hsl(var(--success))",
-          foreground: "hsl(var(--success-foreground))",
-        },
+        bg: "var(--bg)",
+        surface: "var(--surface)",
+        text: "var(--text)",
+        background: "var(--bg)",
+        foreground: "var(--text)",
+        border: "var(--border)",
+        input: "var(--border)",
+        ring: "var(--primary)",
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: "var(--surface)",
+          foreground: "var(--muted-text)",
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: "var(--surface)",
+          foreground: "var(--text)",
         },
-        sidebar: {
-          DEFAULT: "hsl(var(--sidebar-background))",
-          foreground: "hsl(var(--sidebar-foreground))",
-          primary: "hsl(var(--sidebar-primary))",
-          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
-          accent: "hsl(var(--sidebar-accent))",
-          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
-          border: "hsl(var(--sidebar-border))",
-          ring: "hsl(var(--sidebar-ring))",
+        popover: {
+          DEFAULT: "var(--surface)",
+          foreground: "var(--text)",
+        },
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--bg)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--bg)",
+        },
+        secondary: {
+          DEFAULT: "var(--surface)",
+          foreground: "var(--text)",
+        },
+        destructive: {
+          DEFAULT: "#f87171",
+          foreground: "var(--bg)",
         },
       },
-      backgroundImage: {
-        "gradient-hero": "var(--gradient-hero)",
-        "gradient-card": "var(--gradient-card)", 
-        "gradient-primary": "var(--gradient-primary)",
-      },
-      boxShadow: {
-        "enterprise": "var(--shadow-lg)",
-        "card": "var(--shadow-md)",
-        "enterprise-xl": "var(--shadow-xl)",
-      },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-        "fade-up": "fade-up 0.6s ease-out forwards",
-        "slide-in": "slide-in-right 0.5s ease-out forwards",
-        "pulse-primary": "pulse-primary 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
-      },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+      textColor: {
+        muted: "var(--muted-text)",
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        heading: "var(--font-heading)",
+        body: "var(--font-body)",
       },
-      keyframes: {
-        "accordion-down": {
-          from: {
-            height: "0",
-          },
-          to: {
-            height: "var(--radix-accordion-content-height)",
-          },
-        },
-        "accordion-up": {
-          from: {
-            height: "var(--radix-accordion-content-height)",
-          },
-          to: {
-            height: "0",
-          },
-        },
+      borderRadius: {
+        lg: "var(--radius-card)",
+        md: "calc(var(--radius-card) - 4px)",
+        sm: "calc(var(--radius-card) - 8px)",
+        card: "var(--radius-card)",
+        button: "var(--radius-button)",
+        pill: "var(--radius-pill)",
       },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
+      transitionTimingFunction: {
+        fluid: "var(--ease)",
+      },
+      transitionDuration: {
+        enter: "var(--dur-enter)",
+        hover: "var(--dur-hover)",
+        complex: "var(--dur-complex)",
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;
+
+export default config;


### PR DESCRIPTION
## Summary
- add a shared dark design token layer and align Tailwind/global styles with the new palette
- restyle the marketing sections and UI primitives to consume the tokenized colors, typography, and spacing
- introduce motion utilities for reveal/float effects and wire them to route changes with reduced-motion safeguards

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d2b6cd18448320ae31dfc39e277e18